### PR TITLE
activar nav-links con scroll: mejore breakpoints

### DIFF
--- a/js/navegar.js
+++ b/js/navegar.js
@@ -16,7 +16,7 @@ function navegar(e) {
 
 function activarMenu() {
     const REM = 16;
-    const ALTO_BARRA = 4.1 * REM;
+    const ALTO_BARRA = 20 * REM;
     
     const li = document.querySelectorAll(".nav-link");
     const sec = document.querySelectorAll(".destino-nav");


### PR DESCRIPTION
corregi el offset para que se activen los links de navegacion cuando la mitad del contenido ya es visible, en vez de cuando todo el contenido es visible. Principalmente para que se active correctamente el ultimo link de la parte inferior.