### PR TITLE
activar menu on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
             </button>          
             <nav class="collapse navbar-collapse" id="links-navegacion">
                 <ul class="navbar-nav">
-                    <li class="nav-item"><a class="nav-link px-3 active" onclick="navegar(event)" data-target="conferencia">La conferencia</a></li>
+                    <li class="nav-item"><a class="nav-link px-3" onclick="navegar(event)" data-target="conferencia">La conferencia</a></li>
                     <li class="nav-item"><a class="nav-link px-3" onclick="navegar(event)" data-target="oradores">Los oradores</a></li>
                     <li class="nav-item"><a class="nav-link px-3" onclick="navegar(event)" data-target="locacion">El lugar y la fecha</a></li>
                     <li class="nav-item"><a class="nav-link px-3" onclick="navegar(event)" data-target="anotarse">Conviértete en orador</a></li>

--- a/js/navegar.js
+++ b/js/navegar.js
@@ -22,7 +22,7 @@ function activarMenu() {
     }
 
     let seccion = 0;
-    while(scrollY >= quiebresY[seccion + 1]) {
+    while(scrollY >= quiebresY[seccion]) {
         seccion++;
     }
 

--- a/js/navegar.js
+++ b/js/navegar.js
@@ -22,7 +22,7 @@ function activarMenu() {
     }
 
     let seccion = 0;
-    while(scrollY >= quiebresY[seccion]) {
+    while(scrollY >= quiebresY[seccion + 1]) {
         seccion++;
     }
 
@@ -45,6 +45,6 @@ function colapsarMenu()
     }
 }
 
-activarMenu();
 window.addEventListener("scroll", activarMenu);
 window.addEventListener("click", colapsarMenu);
+activarMenu();


### PR DESCRIPTION
corregi el bug: cuando se cargaba la pagina el segundo item de navegacion se resaltaba a pesar de que la pagina se cargaba en la seccion 1.
El menu activo responde correctamente al desplazamiento vertical, y ahora el link correcto se resalta cuando se carga la pagina.